### PR TITLE
Fix time stream algorithm

### DIFF
--- a/percept_parser/percept.py
+++ b/percept_parser/percept.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import json
 import pandas as pd
 import numpy as np
@@ -53,15 +54,15 @@ class PerceptParser:
         dfs_is_td = self.read_timedomain_data(indefinite_streaming=True)
 
         if not df_lfp_trend_logs.empty:
-            if self.stim_settings is not None:
-                df_lfp_trend_logs = self._merge_stim_settings(df_lfp_trend_logs)
+            # if self.stim_settings is not None:
+            #     df_lfp_trend_logs = self._merge_stim_settings(df_lfp_trend_logs)
             df_lfp_trend_logs.to_csv(Path(out_path, "LFPTrendLogs.csv"), index=True)
             if plot:
                 plotter.lfptrendlog_plot(df_lfp_trend_logs, self, path_out=out_path)
 
         if not df_brainsense_lfp.empty:
-            if self.stim_settings is not None:
-                df_brainsense_lfp = self._merge_stim_settings(df_brainsense_lfp)
+            # if self.stim_settings is not None:
+            #     df_brainsense_lfp = self._merge_stim_settings(df_brainsense_lfp)
             df_brainsense_lfp.to_csv(Path(out_path, "BrainSenseLfp.csv"), index=True)
             if plot:
                 df_left = df_brainsense_lfp.query("Hemisphere == 'Left'")
@@ -70,7 +71,9 @@ class PerceptParser:
                 df_right.columns = [f"Right_{col}" for col in df_right.columns]
                 df_brainsense_lfp_comb = pd.concat([df_left, df_right], axis=1)
 
-                plotter.brain_sense_lfp_plot(df_brainsense_lfp_comb, self, out_path=out_path)
+                plotter.brain_sense_lfp_plot(
+                    df_brainsense_lfp_comb, self, out_path=out_path
+                )
 
         if len(dfs_bs_td) > 0:
             if plot:
@@ -83,10 +86,14 @@ class PerceptParser:
                     + f"_{df_bs_td_i.index[-1].strftime('%H-%M-%S')}"
                 )
                 # pivot each column to a channel
-                df_bs_td_i_pivot = df_bs_td_i.reset_index().melt(id_vars=["Time"], var_name="Channel", value_name="Value")
-                df_bs_td_i_pivot["Hemisphere"] = np.where(df_bs_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right")
-                if self.stim_settings is not None:
-                    df_bs_td_i_pivot = self._merge_stim_settings(df_bs_td_i_pivot)
+                df_bs_td_i_pivot = df_bs_td_i.reset_index().melt(
+                    id_vars=["Time"], var_name="Channel", value_name="Value"
+                )
+                df_bs_td_i_pivot["Hemisphere"] = np.where(
+                    df_bs_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right"
+                )
+                # if self.stim_settings is not None:
+                #     df_bs_td_i_pivot = self._merge_stim_settings(df_bs_td_i_pivot)
 
                 df_bs_td_i_pivot.to_csv(
                     Path(out_path, f"BrainSenseTimeDomain_{str_idx}.csv"),
@@ -111,18 +118,23 @@ class PerceptParser:
                     df_is_td_i.index[0].strftime("%Y-%m-%d_%H-%M-%S")
                     + f"_{df_is_td_i.index[-1].strftime('%H-%M-%S')}"
                 )
-                df_is_td_i_pivot = df_is_td_i.reset_index().melt(id_vars=["Time"], var_name="Channel", value_name="Value")
-                df_is_td_i_pivot["Hemisphere"] = np.where(df_is_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right")
-                if self.stim_settings is not None:
-                    df_is_td_i_pivot = self._merge_stim_settings(df_is_td_i_pivot)
-                else:
-                    # set Time as index
-                    df_is_td_i_pivot = df_is_td_i_pivot.set_index("Time")
+                df_is_td_i_pivot = df_is_td_i.reset_index().melt(
+                    id_vars=["Time"], var_name="Channel", value_name="Value"
+                )
+                # df_is_td_i_pivot["Hemisphere"] = np.where(
+                #     df_is_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right"
+                # )
+                # if self.stim_settings is not None:
+                #     df_is_td_i_pivot = self._merge_stim_settings(df_is_td_i_pivot)
+                # else:
+                # set Time as index
+                df_is_td_i_pivot = df_is_td_i_pivot.set_index("Time")
                 df_is_td_i_pivot.to_csv(
                     Path(out_path, f"IndefiniteStreaming_{str_idx}.csv"),
                     index=True,
                 )
                 if plot:
+                    print("outpath", out_path)
                     plotter.plot_df_timeseries(df_is_td_i, out_path=out_path)
                     plotter.time_frequency_plot_td(
                         df_is_td_i,
@@ -138,7 +150,9 @@ class PerceptParser:
         # recent stim settings that started before sample time.
         samples_with_group = pd.merge_asof(
             samples_with_time.sort_values("Time"),
-            self.stim_settings.active_group_history.rename(columns={"hem": "Hemisphere"}),
+            self.stim_settings.active_group_history.rename(
+                columns={"hem": "Hemisphere"}
+            ),
             left_on="Time",
             right_on="start_time",
             direction="backward",
@@ -158,7 +172,7 @@ class PerceptParser:
             n_invalid = len(invalid_samples)
             total = len(samples_with_group)
             warnings.warn(
-                f"{n_invalid}/{total} samples ({100*n_invalid/total:.1f}%) fell into "
+                f"{n_invalid}/{total} samples ({100 * n_invalid / total:.1f}%) fell into "
                 f"INVALID group periods (group switched to undefined configuration). "
                 f"These samples dont have defined settings."
             )
@@ -221,7 +235,7 @@ class PerceptParser:
                         "TicksInMses": sample["TicksInMs"],
                         "Power": sample[hem]["LFP"],
                         "Stim_current": sample[hem]["mA"],
-                        "Hemisphere": hem
+                        "Hemisphere": hem,
                     }
                     for hem in ["Left", "Right"]  # For each hem
                     for sample in stream["LfpData"]
@@ -244,49 +258,86 @@ class PerceptParser:
 
     def get_time_stream(
         self, js_td: dict, num_chs: int, verbose: bool = False
-    ) -> pd.DataFrame:
-        start_time = js_td["FirstPacketDateTime"]
-        start_time = pd.Timestamp(start_time)
+    ) -> tuple[pd.DataFrame, pd.DataFrame, bool]:
+        """Estimate relative time at which each datapoint in a BrainSenseTimeDomain
+        or IndefiniteStreaming data stream was sampled.  Uses the algorithm defined
+        in page 35 of Medtronic's DBS Sensing And Adaptive Therapy White Paper
+
+        Args:
+            stream_json (dict): _description_
+            num_chs (int): _description_
+            verbose (bool, optional): _description_. Defaults to False.
+
+        Raises:
+            ValueError: _description_
+            ValueError: _description_
+            ValueError: _description_
+
+        Returns:
+            pd.DataFrame: _description_
+        """
+        # Absolute datetime for the first sent pacakge of the stream
+        first_packet_time = datetime.fromisoformat(js_td["FirstPacketDateTime"])
+
+        # Recording sample rate for this data stream
         fs = js_td["SampleRateInHz"]
+
+        # Measurement value for each datapoint at SampleRateInHz
         TimeDomainData = np.array(js_td["TimeDomainData"])
-        TicksInMses = np.array(
-            [int(tick) for tick in js_td["TicksInMses"].split(",")[:-1]]
-        )
-        TicksDiff = np.diff(TicksInMses)
-        GlobalPacketSizes = np.array(
-            [int(size) for size in js_td["GlobalPacketSizes"].split(",")[:-1]]
-        )
-        GlobalSequences = np.array(
-            [int(seq) for seq in js_td["GlobalSequences"].split(",")[:-1]]
+
+        #  List of number of samples per telemetry packet
+        GlobalPacketSizes = np.fromstring(
+            js_td["GlobalPacketSizes"], sep=",", dtype=int
         )
 
-        if sum(GlobalPacketSizes) != TimeDomainData.shape[0]:
+        # Recording device system tick at the moment of package transmission
+        TicksInMses = np.fromstring(js_td["TicksInMses"], sep=",", dtype=int)
+
+        # Integrity check: The sum of packet sizes should match the namber of data points
+        if np.sum(GlobalPacketSizes) != TimeDomainData.shape[0]:
             raise ValueError("GlobalPacketSizes does not match TimeDomainData length")
 
-        df_i = pd.DataFrame(
-            {
-                "GlobalPacketSizes": GlobalPacketSizes,
-                "GlobalSequences": GlobalSequences,
-                "TicksInMsesDiff": np.concatenate([np.array([np.nan]), TicksDiff]),
-                "TicksInMses": TicksInMses,
-            }
-        )
+        # Integrity check: The amount of packets should match the array of packet send times
+        if len(GlobalPacketSizes) != len(TicksInMses):
+            raise ValueError("Inconsistent number of packets in stream")
+
+        # Differences in tick between sent packages, to check for package loss
+        TicksDiff = np.concatenate([np.diff(TicksInMses), np.array([np.nan])])
+
+        # Check that packages are sorteds
+        # if not np.all(TicksInMses[:-1] <= TicksInMses[1:]):
+        #     raise ValueError("Packages in the wrong order")
+
+        # df_i = pd.DataFrame(
+        #     {
+        #         "GlobalPacketSizes": GlobalPacketSizes,
+        #         "TicksInMsesDiff": TicksDiff,
+        #         "TicksInMses": TicksInMses,
+        #     }
+        # )
+        # print(df_i)
 
         # if indefinite_streaming:
         #     # collapse df_i
         #     idx_250_before = df_i.query("TicksInMsesDiff == 250").index-1
 
-        un, counts = np.unique(TicksDiff, return_counts=True)
+        un, counts = np.unique(np.diff(TicksInMses), return_counts=True)
         df_counts = pd.DataFrame({"TicksDiff": un, "Counts": counts})
 
-        tdtime = np.arange(0, df_i.iloc[0]["GlobalPacketSizes"] / fs, 1 / fs)
-        t_cur = tdtime[-1] + (1 / fs)  # First time of next packet
-
-        l_tdtime = []
-        l_tdtime.append(tdtime)
+        # According to the algorithm described in the whitepaper, we have to iterate backwards
+        period_ms = 1000 / fs  # Gap between data points in milliseconds
+        num_packets = len(GlobalPacketSizes)
         PACKAGE_LOSS_PRESENT = False
-        for i in np.arange(1, df_i.shape[0], 1):
-            time_diff = df_i.iloc[i]["TicksInMsesDiff"] / 1000  # s
+
+        # Start with he last packet
+        last_packet_size = GlobalPacketSizes[-1]
+        tick_ms_end = TicksInMses[-1]
+        start_time = tick_ms_end - (last_packet_size - 1) * period_ms
+        tdtime = np.linspace(start_time, tick_ms_end, last_packet_size)
+
+        # Continue from second to last and backwards
+        for i in range(num_packets - 2, -1, -1):
+            time_diff = TicksDiff[i] / 1000  # s
 
             # for indefinite streaming with 6 chs diffs are 250
             # for brainsense time domain data there are two chs
@@ -298,58 +349,56 @@ class PerceptParser:
                 time_diff = time_diff / 3  # here I don't know,
             elif num_chs == 6:
                 time_diff = time_diff / 2
-            if time_diff < 0:
-                time_diff = np.unique(TicksDiff)[0] / 1000  # s, most freq value
 
-            td_time_packet = np.arange(
-                0, df_i.iloc[i]["GlobalPacketSizes"] / fs, 1 / fs
-            )
+            # Is this even possible? If so, would need to reorder TimeDomainData
+            # if time_diff < 0:
+            #     time_diff = np.bincount(TicksDiff).argmax() / 1000  # most freq value
 
-            if time_diff > (df_i.iloc[i]["GlobalPacketSizes"] + 1) / fs:
+            # Should I use this one or previous one for time diff check?
+            packet_size = GlobalPacketSizes[i]
+
+            # In case of packet loss (time between packets too long)
+            if time_diff > (packet_size + 1) / fs:  # If packages missing
                 PACKAGE_LOSS_PRESENT = True
-                td_time_packet += t_cur + time_diff - td_time_packet[-1]
+                end_time = TicksInMses[i]  # Re-anchor time using the ticks
+                start_time = end_time - (packet_size - 1) * period_ms
+                tdtime_packet = np.linspace(start_time, end_time, packet_size)
+                # And join with the previous
+                tdtime = np.concat((tdtime_packet, tdtime))
             else:
-                # To get t_cur to first time of packet after adjusting for missing packets:
-                # 1. Revert t_cur to end of previous of package
-                # 2. Advance by time diff between packets
-                # 3. Go back by the duration of this packet
-                # td_time_packet += (t_cur - 1 / fs) + time_diff - td_time_packet[-1]
-                # Note: because time_diff is rounded to the 50ms, there are rounding errors of 2ms per lost packet
-                # Whitepaper suggests just using the TicksInMses values
-                # However, this method still is 4ms off in some cases
-                td_time_packet += (
-                    ((TicksInMses[i] - TicksInMses[0]) / 1000)  # End of packet
-                    - td_time_packet[-1]  # Offset to start of packet
-                    # Take into account that TicksInMs[0] is END of first packet
-                    + (GlobalPacketSizes[0] - 1) / fs
-                )
-                if verbose:
-                    print(f"td_time_ shape: {td_time_packet.shape}")
-                    print(f"GlobalPacketSizes: {df_i.iloc[i]['GlobalPacketSizes']}\n")
-                if td_time_packet.shape[0] != df_i.iloc[i]["GlobalPacketSizes"]:
-                    raise ValueError(
-                        f"td_time_ shape {td_time_packet.shape} does not match GlobalPacketSizes {df_i.iloc[i]['GlobalPacketSizes']}"
-                    )
+                # If no packet loss, assume data is continuous
+                end_time = tdtime[0] - period_ms  # Account for gap betwen packets
+                start_time = end_time - (packet_size - 1) * period_ms
+                tdtime_packet = np.linspace(start_time, end_time, packet_size)
 
-            t_cur = np.round(td_time_packet[-1] + 1 / fs, decimals=3)  # First time of next packet
-            l_tdtime.append(td_time_packet)
-            tdtime = np.concatenate([tdtime, td_time_packet])
+                if verbose:
+                    print(f"td_time_ shape: {tdtime_packet.shape}")
+                    print(f"GlobalPacketSizes: {GlobalPacketSizes[i]}\n")
+                if tdtime_packet.shape[0] != GlobalPacketSizes[i]:
+                    raise ValueError(
+                        f"td_time_ shape {tdtime_packet.shape} does not match GlobalPacketSizes {GlobalPacketSizes[i]}"
+                    )
+                tdtime = np.concat((tdtime_packet, tdtime))
 
         # Check that calculation was correct by comparing to actual last value from TicksInMses
         # print(
-        #     f"Computed last value {tdtime[-1]}",
+        #     f"Computed first value {tdtime[0]}",
         #     f"Theoretical last value: {
-        #         (TicksInMses[-1] - TicksInMses[0]) / 1000
-        #         + (GlobalPacketSizes[0] - 1) / fs
+        #         TicksInMses[0] - (GlobalPacketSizes[0] - 1) * period_ms
         #     }",
         # )
 
+        tdtime -= tdtime[0]  # Start at 0
+        tdtime /= 1000  # To seconds
+
+        # Assert that the time array has the same shape as the measurements array
+        # (i.e. all measurements have been assigned a timestamp)
         if tdtime.shape[0] != TimeDomainData.shape[0]:
             raise ValueError(
-                f"tdtime shape {tdtime.shape} does not match TimeDomainData shape {TimeDomainData.shape}"
+                f"tdtime shape {tdtime_packet.shape} does not match TimeDomainData shape {TimeDomainData.shape}"
             )
 
-        td_ = pd.to_timedelta(tdtime, unit="s") + pd.Timestamp(start_time)
+        td_ = pd.to_timedelta(tdtime, unit="s") + pd.Timestamp(first_packet_time)
         ch_ = js_td["Channel"]
         df_ch = pd.DataFrame(
             {
@@ -376,7 +425,9 @@ class PerceptParser:
 
         return df_ch, df_counts, PACKAGE_LOSS_PRESENT
 
-    def read_timedomain_data(self, indefinite_streaming: bool = True) -> pd.DataFrame:
+    def read_timedomain_data(
+        self, indefinite_streaming: bool = True
+    ) -> list[pd.DataFrame]:
         if indefinite_streaming:
             str_timedomain = "IndefiniteStreaming"
         else:
@@ -404,11 +455,15 @@ class PerceptParser:
             df_chs = []
             idx_package_chs = np.where(FirstPackageDateTimes == first_package)[0]
             for pkg_ch_idx in idx_package_chs:
-                df_ch, df_counts, PACKAGE_LOSS_PRESENT = self.get_time_stream(
-                    js_td=self.js[str_timedomain][pkg_ch_idx],
-                    num_chs=num_chs,
-                    verbose=False,
-                )
+                try:
+                    df_ch, df_counts, PACKAGE_LOSS_PRESENT = self.get_time_stream(
+                        js_td=self.js[str_timedomain][pkg_ch_idx],
+                        num_chs=num_chs,
+                        verbose=False,
+                    )
+                except Exception as e:
+                    print(e)
+
                 df_counts["file_idx"] = package_idx
                 df_counts_sum.append(df_counts)
                 df_chs.append(df_ch)
@@ -419,65 +474,3 @@ class PerceptParser:
             )
             df_.append(df_concat)
         return df_
-
-    # def read_brainsense_timedomain(
-    #     self,
-    # ) -> pd.DataFrame:
-    #     if "BrainSenseTimeDomain" not in self.js:
-    #         print("No BrainSenseTimeDomain found in the JSON file.")
-    #         return pd.DataFrame()
-
-    #     df_counts_sum = []
-    #     df_chs = []
-    #     for index_ in tqdm(
-    #         range(len(self.js["BrainSenseTimeDomain"])), desc="BSTimeDomain Index"
-    #     ):
-    #         df_ch, df_counts, PACKAGE_LOSS_PRESENT = self.get_time_stream(
-    #             self.js["BrainSenseTimeDomain"][index_],
-    #             False,
-    #             indefinite_streaming=False,
-    #         )
-    #         df_counts["file_idx"] = index_
-    #         df_counts_sum.append(df_counts)
-
-    #         df_chs.append(df_ch)
-    #     df_concat = pd.concat(df_chs, axis=0).reset_index()
-    #     df_concat = df_concat.drop_duplicates(subset=["Time", "Channel"])
-    #     df_concat = df_concat.reset_index().pivot(
-    #         index="Time", columns="Channel", values="Data"
-    #     )
-
-    #     df_counts = pd.concat(df_counts_sum, axis=0)
-    #     df_counts["Time_Diff_Total"] = df_counts["Counts"] * df_counts["TicksDiff"]
-    #     file_sum = df_counts.groupby("file_idx")["Time_Diff_Total"].sum().reset_index()
-    #     file_missing = (
-    #         df_counts.query("TicksDiff != 250")
-    #         .groupby("file_idx")["Time_Diff_Total"]
-    #         .sum()
-    #         .reset_index()
-    #     )
-
-    #     df_counts_file_idx = pd.merge(
-    #         file_sum,
-    #         file_missing,
-    #         on="file_idx",
-    #         how="outer",
-    #         suffixes=("_sum", "_missing"),
-    #     )
-    #     df_counts_file_idx = df_counts_file_idx.fillna(0)
-    #     df_counts_file_idx = df_counts_file_idx.sort_values(
-    #         by="Time_Diff_Total_missing", ascending=True
-    #     ).iloc[::2]
-
-    #     df_counts_file_idx["Time_Diff_Total_sum"] = (
-    #         df_counts_file_idx["Time_Diff_Total_sum"] / 1000
-    #     )
-    #     df_counts_file_idx["Time_Diff_Total_missing"] = (
-    #         df_counts_file_idx["Time_Diff_Total_missing"] / 1000
-    #     )
-
-    #     df_counts_file_idx["Time_Diff_Total_missing_clipped"] = df_counts_file_idx[
-    #         "Time_Diff_Total_missing"
-    #     ].clip(upper=10)
-
-    #     return df_concat, df_counts_file_idx

--- a/percept_parser/percept.py
+++ b/percept_parser/percept.py
@@ -54,15 +54,15 @@ class PerceptParser:
         dfs_is_td = self.read_timedomain_data(indefinite_streaming=True)
 
         if not df_lfp_trend_logs.empty:
-            # if self.stim_settings is not None:
-            #     df_lfp_trend_logs = self._merge_stim_settings(df_lfp_trend_logs)
+            if self.stim_settings is not None:
+                df_lfp_trend_logs = self._merge_stim_settings(df_lfp_trend_logs)
             df_lfp_trend_logs.to_csv(Path(out_path, "LFPTrendLogs.csv"), index=True)
             if plot:
                 plotter.lfptrendlog_plot(df_lfp_trend_logs, self, path_out=out_path)
 
         if not df_brainsense_lfp.empty:
-            # if self.stim_settings is not None:
-            #     df_brainsense_lfp = self._merge_stim_settings(df_brainsense_lfp)
+            if self.stim_settings is not None:
+                df_brainsense_lfp = self._merge_stim_settings(df_brainsense_lfp)
             df_brainsense_lfp.to_csv(Path(out_path, "BrainSenseLfp.csv"), index=True)
             if plot:
                 df_left = df_brainsense_lfp.query("Hemisphere == 'Left'")
@@ -92,8 +92,8 @@ class PerceptParser:
                 df_bs_td_i_pivot["Hemisphere"] = np.where(
                     df_bs_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right"
                 )
-                # if self.stim_settings is not None:
-                #     df_bs_td_i_pivot = self._merge_stim_settings(df_bs_td_i_pivot)
+                if self.stim_settings is not None:
+                    df_bs_td_i_pivot = self._merge_stim_settings(df_bs_td_i_pivot)
 
                 df_bs_td_i_pivot.to_csv(
                     Path(out_path, f"BrainSenseTimeDomain_{str_idx}.csv"),
@@ -121,14 +121,14 @@ class PerceptParser:
                 df_is_td_i_pivot = df_is_td_i.reset_index().melt(
                     id_vars=["Time"], var_name="Channel", value_name="Value"
                 )
-                # df_is_td_i_pivot["Hemisphere"] = np.where(
-                #     df_is_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right"
-                # )
-                # if self.stim_settings is not None:
-                #     df_is_td_i_pivot = self._merge_stim_settings(df_is_td_i_pivot)
-                # else:
-                # set Time as index
-                df_is_td_i_pivot = df_is_td_i_pivot.set_index("Time")
+                df_is_td_i_pivot["Hemisphere"] = np.where(
+                    df_is_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right"
+                )
+                if self.stim_settings is not None:
+                    df_is_td_i_pivot = self._merge_stim_settings(df_is_td_i_pivot)
+                else:
+                    # set Time as index
+                    df_is_td_i_pivot = df_is_td_i_pivot.set_index("Time")
                 df_is_td_i_pivot.to_csv(
                     Path(out_path, f"IndefiniteStreaming_{str_idx}.csv"),
                     index=True,
@@ -146,13 +146,25 @@ class PerceptParser:
     def _merge_stim_settings(self, samples) -> pd.DataFrame:
         samples_with_time = samples.reset_index()
 
+        # Make sure time has same format in both tables before merging
+        if samples_with_time["Time"].dtype != "datetime64[ns, UTC]":
+            samples_with_time["Time"] = samples_with_time["Time"].astype(
+                "datetime64[ns, UTC]"
+            )
+
+        stim_history = self.stim_settings.active_group_history.rename(
+            columns={"hem": "Hemisphere"}
+        )
+        if stim_history["start_time"].dtype != "datetime64[ns, UTC]":
+            stim_history["start_time"] = stim_history["start_time"].astype(
+                "datetime64[ns, UTC]"
+            )
+
         # Merge asof backwards will perform a left join, matching each sample with the most
         # recent stim settings that started before sample time.
         samples_with_group = pd.merge_asof(
             samples_with_time.sort_values("Time"),
-            self.stim_settings.active_group_history.rename(
-                columns={"hem": "Hemisphere"}
-            ),
+            stim_history,
             left_on="Time",
             right_on="start_time",
             direction="backward",
@@ -274,7 +286,7 @@ class PerceptParser:
             ValueError: _description_
 
         Returns:
-            pd.DataFrame: _description_
+            tuple[pd.DataFrame, pd.DataFrame, bool]: (df_ch, df_counts, PACKAGE_LOSS_PRESENT)
         """
         # Absolute datetime for the first sent pacakge of the stream
         first_packet_time = datetime.fromisoformat(js_td["FirstPacketDateTime"])
@@ -304,18 +316,9 @@ class PerceptParser:
         # Differences in tick between sent packages, to check for package loss
         TicksDiff = np.concatenate([np.diff(TicksInMses), np.array([np.nan])])
 
-        # Check that packages are sorteds
+        # Check that packages are sorteds (sometimes this fails, which is worrysome)
         # if not np.all(TicksInMses[:-1] <= TicksInMses[1:]):
         #     raise ValueError("Packages in the wrong order")
-
-        # df_i = pd.DataFrame(
-        #     {
-        #         "GlobalPacketSizes": GlobalPacketSizes,
-        #         "TicksInMsesDiff": TicksDiff,
-        #         "TicksInMses": TicksInMses,
-        #     }
-        # )
-        # print(df_i)
 
         # if indefinite_streaming:
         #     # collapse df_i
@@ -327,12 +330,12 @@ class PerceptParser:
         # According to the algorithm described in the whitepaper, we have to iterate backwards
         period_ms = 1000 / fs  # Gap between data points in milliseconds
         num_packets = len(GlobalPacketSizes)
-        PACKAGE_LOSS_PRESENT = False
 
         # Start with he last packet
         last_packet_size = GlobalPacketSizes[-1]
         tick_ms_end = TicksInMses[-1]
         start_time = tick_ms_end - (last_packet_size - 1) * period_ms
+        PACKAGE_LOSS_PRESENT = False
         tdtime = np.linspace(start_time, tick_ms_end, last_packet_size)
 
         # Continue from second to last and backwards
@@ -380,14 +383,6 @@ class PerceptParser:
                     )
                 tdtime = np.concat((tdtime_packet, tdtime))
 
-        # Check that calculation was correct by comparing to actual last value from TicksInMses
-        # print(
-        #     f"Computed first value {tdtime[0]}",
-        #     f"Theoretical last value: {
-        #         TicksInMses[0] - (GlobalPacketSizes[0] - 1) * period_ms
-        #     }",
-        # )
-
         tdtime -= tdtime[0]  # Start at 0
         tdtime /= 1000  # To seconds
 
@@ -398,6 +393,7 @@ class PerceptParser:
                 f"tdtime shape {tdtime_packet.shape} does not match TimeDomainData shape {TimeDomainData.shape}"
             )
 
+        # Convert to dataframe
         td_ = pd.to_timedelta(tdtime, unit="s") + pd.Timestamp(first_packet_time)
         ch_ = js_td["Channel"]
         df_ch = pd.DataFrame(

--- a/percept_parser/percept.py
+++ b/percept_parser/percept.py
@@ -71,7 +71,9 @@ class PerceptParser:
                 df_right.columns = [f"Right_{col}" for col in df_right.columns]
                 df_brainsense_lfp_comb = pd.concat([df_left, df_right], axis=1)
 
-                plotter.brain_sense_lfp_plot(df_brainsense_lfp_comb, self, out_path=out_path)
+                plotter.brain_sense_lfp_plot(
+                    df_brainsense_lfp_comb, self, out_path=out_path
+                )
 
         if len(dfs_bs_td) > 0:
             if plot:
@@ -84,8 +86,12 @@ class PerceptParser:
                     + f"_{df_bs_td_i.index[-1].strftime('%H-%M-%S')}"
                 )
                 # pivot each column to a channel
-                df_bs_td_i_pivot = df_bs_td_i.reset_index().melt(id_vars=["Time"], var_name="Channel", value_name="Value")
-                df_bs_td_i_pivot["Hemisphere"] = np.where(df_bs_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right")
+                df_bs_td_i_pivot = df_bs_td_i.reset_index().melt(
+                    id_vars=["Time"], var_name="Channel", value_name="Value"
+                )
+                df_bs_td_i_pivot["Hemisphere"] = np.where(
+                    df_bs_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right"
+                )
                 if self.stim_settings is not None:
                     df_bs_td_i_pivot = self._merge_stim_settings(df_bs_td_i_pivot)
 
@@ -112,8 +118,12 @@ class PerceptParser:
                     df_is_td_i.index[0].strftime("%Y-%m-%d_%H-%M-%S")
                     + f"_{df_is_td_i.index[-1].strftime('%H-%M-%S')}"
                 )
-                df_is_td_i_pivot = df_is_td_i.reset_index().melt(id_vars=["Time"], var_name="Channel", value_name="Value")
-                df_is_td_i_pivot["Hemisphere"] = np.where(df_is_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right")
+                df_is_td_i_pivot = df_is_td_i.reset_index().melt(
+                    id_vars=["Time"], var_name="Channel", value_name="Value"
+                )
+                df_is_td_i_pivot["Hemisphere"] = np.where(
+                    df_is_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right"
+                )
                 if self.stim_settings is not None:
                     df_is_td_i_pivot = self._merge_stim_settings(df_is_td_i_pivot)
                 else:
@@ -265,9 +275,9 @@ class PerceptParser:
         in page 35 of Medtronic's DBS Sensing And Adaptive Therapy White Paper
 
         Args:
-            stream_json (dict): _description_
-            num_chs (int): _description_
-            verbose (bool, optional): _description_. Defaults to False.
+            js_td (dict): Section of the Percept JSON that contains the TimeDomain data, either BrainSenseTimeDomain or IndefiniteStreaming
+            num_chs (int): Number of channels in the recording
+            verbose (bool, optional): Defaults to False.
 
         Raises:
             ValueError: _description_
@@ -413,45 +423,54 @@ class PerceptParser:
     def read_timedomain_data(
         self, indefinite_streaming: bool = True
     ) -> list[pd.DataFrame]:
-        if indefinite_streaming:
-            str_timedomain = "IndefiniteStreaming"
-        else:
-            str_timedomain = "BrainSenseTimeDomain"
+        """_summary_
+
+        Args:
+            indefinite_streaming (bool, optional): Attempt to read IndefiniteStreaming data, otherwise defaults to BrainSenseTimeDomain.
+
+        Returns:
+            list[pd.DataFrame]: List of Dataframes, one per streaming session. Each dataframe contains one series per channel
+        """
+
+        str_timedomain = (
+            "IndefiniteStreaming" if indefinite_streaming else "BrainSenseTimeDomain"
+        )
+
         if str_timedomain not in self.js:
             print(f"No {str_timedomain} found in the JSON file.")
             return []
 
+        timedomain_data = self.js[str_timedomain]
+
+        # We can identify the streaming sessions accross different channels by looking at their timestamp
         FirstPackageDateTimes = np.array(
-            [
-                self.js[str_timedomain][index_]["FirstPacketDateTime"]
-                for index_ in range(len(self.js[str_timedomain]))
-            ]
+            [stream["FirstPacketDateTime"] for stream in timedomain_data]
         )
-        num_chs = np.where(FirstPackageDateTimes == FirstPackageDateTimes[0])[0].shape[
-            0
+
+        # For each timestamp (~stream) we get the index for the recordings, one per channel
+        list_stream_channels = [
+            np.where(FirstPackageDateTimes == timestamp)[0]
+            for timestamp in np.unique(FirstPackageDateTimes)
         ]
 
+        # Iterate over streams, processing each time series (one per stream and channel)
         df_ = []
-        for package_idx, first_package in tqdm(
-            list(enumerate(np.unique(FirstPackageDateTimes))),
-            desc=f"{str_timedomain} Index",
-        ):
-            df_counts_sum = []
-            df_chs = []
-            idx_package_chs = np.where(FirstPackageDateTimes == first_package)[0]
-            for pkg_ch_idx in idx_package_chs:
+        for stream_channels in tqdm(list_stream_channels, desc=f"{str_timedomain} Index"):
+            # df_counts_sum = []
+            df_chs = [] #  Store here all channels for the same stream
+            for channel_idx in stream_channels:
                 try:
                     df_ch, df_counts, PACKAGE_LOSS_PRESENT = self.get_time_stream(
-                        js_td=self.js[str_timedomain][pkg_ch_idx],
-                        num_chs=num_chs,
+                        js_td=timedomain_data[channel_idx],
+                        num_chs=len(stream_channels),
                         verbose=False,
                     )
+                    df_chs.append(df_ch)
                 except Exception as e:
                     print(e)
 
-                df_counts["file_idx"] = package_idx
-                df_counts_sum.append(df_counts)
-                df_chs.append(df_ch)
+                # df_counts["file_idx"] = package_idx
+                # df_counts_sum.append(df_counts)
 
             df_concat = pd.concat(df_chs, axis=0)
             df_concat = df_concat.reset_index().pivot(

--- a/percept_parser/percept.py
+++ b/percept_parser/percept.py
@@ -71,9 +71,7 @@ class PerceptParser:
                 df_right.columns = [f"Right_{col}" for col in df_right.columns]
                 df_brainsense_lfp_comb = pd.concat([df_left, df_right], axis=1)
 
-                plotter.brain_sense_lfp_plot(
-                    df_brainsense_lfp_comb, self, out_path=out_path
-                )
+                plotter.brain_sense_lfp_plot(df_brainsense_lfp_comb, self, out_path=out_path)
 
         if len(dfs_bs_td) > 0:
             if plot:
@@ -86,12 +84,8 @@ class PerceptParser:
                     + f"_{df_bs_td_i.index[-1].strftime('%H-%M-%S')}"
                 )
                 # pivot each column to a channel
-                df_bs_td_i_pivot = df_bs_td_i.reset_index().melt(
-                    id_vars=["Time"], var_name="Channel", value_name="Value"
-                )
-                df_bs_td_i_pivot["Hemisphere"] = np.where(
-                    df_bs_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right"
-                )
+                df_bs_td_i_pivot = df_bs_td_i.reset_index().melt(id_vars=["Time"], var_name="Channel", value_name="Value")
+                df_bs_td_i_pivot["Hemisphere"] = np.where(df_bs_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right")
                 if self.stim_settings is not None:
                     df_bs_td_i_pivot = self._merge_stim_settings(df_bs_td_i_pivot)
 
@@ -118,12 +112,8 @@ class PerceptParser:
                     df_is_td_i.index[0].strftime("%Y-%m-%d_%H-%M-%S")
                     + f"_{df_is_td_i.index[-1].strftime('%H-%M-%S')}"
                 )
-                df_is_td_i_pivot = df_is_td_i.reset_index().melt(
-                    id_vars=["Time"], var_name="Channel", value_name="Value"
-                )
-                df_is_td_i_pivot["Hemisphere"] = np.where(
-                    df_is_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right"
-                )
+                df_is_td_i_pivot = df_is_td_i.reset_index().melt(id_vars=["Time"], var_name="Channel", value_name="Value")
+                df_is_td_i_pivot["Hemisphere"] = np.where(df_is_td_i_pivot["Channel"].str.contains("LEFT"), "Left", "Right")
                 if self.stim_settings is not None:
                     df_is_td_i_pivot = self._merge_stim_settings(df_is_td_i_pivot)
                 else:
@@ -134,7 +124,6 @@ class PerceptParser:
                     index=True,
                 )
                 if plot:
-                    print("outpath", out_path)
                     plotter.plot_df_timeseries(df_is_td_i, out_path=out_path)
                     plotter.time_frequency_plot_td(
                         df_is_td_i,

--- a/percept_parser/plotter.py
+++ b/percept_parser/plotter.py
@@ -346,7 +346,6 @@ def plot_df_timeseries(
     else:
         str_prefix = "istd_"
     pdf_path = f"{out_path}/{str_prefix}{df_plt.index[0].strftime(FILE_DATETIME_FORMAT)}_{df_plt.index[-1].strftime(FILE_DATETIME_FORMAT)}.pdf"
-    print("pdf_path", pdf_path)
     pdf_ = PdfPages(pdf_path)
     TIME_INTERVAL = 10
     samples = 250 * TIME_INTERVAL

--- a/percept_parser/plotter.py
+++ b/percept_parser/plotter.py
@@ -8,8 +8,13 @@ from tqdm import tqdm
 from matplotlib.backends.backend_pdf import PdfPages
 import mne
 
+PLOT_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+FILE_DATETIME_FORMAT = "%Y-%m-%d_%H-%M-%S"
 
-def brain_sense_lfp_plot(df: pd.DataFrame, parser, out_path: str, quantile: float = 0.99):
+
+def brain_sense_lfp_plot(
+    df: pd.DataFrame, parser, out_path: str, quantile: float = 0.99
+):
     df = df
     parser = parser
     out_path = out_path
@@ -20,10 +25,12 @@ def brain_sense_lfp_plot(df: pd.DataFrame, parser, out_path: str, quantile: floa
     plt.plot(df.index, df["Right_Power"], label="Right LFP")
     plt.xlabel("Time")
     plt.ylabel("LFP Power [a.u.]")
-    plt.title(f"LFP power over Time, date: {parser.session_date.strftime('%Y-%m-%d %H:%M:%S')} - {parser.lead_location} - {parser.lead_model}\n"
-            f"{df.index[0].strftime('%Y-%m-%d %H:%M:%S')} - {df.index[-1].strftime('%Y-%m-%d %H:%M:%S')}\n"
-            f"LeadLocation: {parser.lead_location}, LeadModel: {parser.lead_model}\n"
-            f"All samples")
+    plt.title(
+        f"LFP power over Time, date: {parser.session_date.strftime(PLOT_DATETIME_FORMAT)} - {parser.lead_location} - {parser.lead_model}\n"
+        f"{df.index[0].strftime(PLOT_DATETIME_FORMAT)} - {df.index[-1].strftime(PLOT_DATETIME_FORMAT)}\n"
+        f"LeadLocation: {parser.lead_location}, LeadModel: {parser.lead_model}\n"
+        f"All samples"
+    )
 
     plt.subplot(3, 1, 2)
     plt.plot(df.index, df["Left_Power"], label="Left LFP", alpha=0.8)
@@ -49,6 +56,7 @@ def brain_sense_lfp_plot(df: pd.DataFrame, parser, out_path: str, quantile: floa
     plt.savefig(f"{out_path}/lfp_power_plot.pdf")
     plt.close()
 
+
 def lfptrendlog_plot(df_trend_logs: pd.DataFrame, parser, path_out: str):
     df_trend_logs = df_trend_logs
     parser = parser
@@ -58,28 +66,35 @@ def lfptrendlog_plot(df_trend_logs: pd.DataFrame, parser, path_out: str):
     for hem in df_trend_logs["Hemisphere"].unique():
         df_hem = df_trend_logs[df_trend_logs["Hemisphere"] == hem]
         plt.plot(df_hem.index, df_hem["LFP"], label=f"{hem} LFP Trend Logs")
-    plt.gca().xaxis.set_major_formatter(mdates.DateFormatter('%m-%d'))
+    plt.gca().xaxis.set_major_formatter(mdates.DateFormatter("%m-%d"))
     plt.xlabel("Time")
     plt.ylabel("LFP Trend Power [a.u.]")
-    plt.title(f"LFP Trend Logs over Time, date: {parser.session_date.strftime('%Y-%m-%d %H:%M:%S')} - {parser.lead_location} - {parser.lead_model}\n"
-            f"{df_trend_logs.index[0].strftime('%Y-%m-%d %H:%M:%S')} - {df_trend_logs.index[-1].strftime('%Y-%m-%d %H:%M:%S')}\n"
-            f"LeadLocation: {parser.lead_location}, LeadModel: {parser.lead_model}")
+    plt.title(
+        f"LFP Trend Logs over Time, date: {parser.session_date.strftime(PLOT_DATETIME_FORMAT)} - {parser.lead_location} - {parser.lead_model}\n"
+        f"{df_trend_logs.index[0].strftime(PLOT_DATETIME_FORMAT)} - {df_trend_logs.index[-1].strftime(PLOT_DATETIME_FORMAT)}\n"
+        f"LeadLocation: {parser.lead_location}, LeadModel: {parser.lead_model}"
+    )
     plt.legend()
     plt.tight_layout()
     plt.savefig(f"{path_out}/lfp_trend_logs_plot.pdf")
     plt.close()
 
-def brainsense_timedomain_plot(df_bs_td: pd.DataFrame, parser, out_path: str, indefinite_streaming: bool = False):
+
+def brainsense_timedomain_plot(
+    df_bs_td: pd.DataFrame, parser, out_path: str, indefinite_streaming: bool = False
+):
     ch_names = list(df_bs_td.columns)
 
     plt.figure(figsize=(15, 5))
     for ch_idx, ch in enumerate(ch_names):
-        plt.plot(df_bs_td.index, df_bs_td[ch] + 100*ch_idx, label=ch)
+        plt.plot(df_bs_td.index, df_bs_td[ch] + 100 * ch_idx, label=ch)
     plt.xlabel("Time")
     plt.ylabel("Amplitude")
-    plt.title(f"BrainSense Time Domain Data - {parser.session_date.strftime('%Y-%m-%d %H:%M:%S')} - {parser.lead_location} - {parser.lead_model}\n"
-            f"{df_bs_td.index[0].strftime('%Y-%m-%d %H:%M:%S')} - {df_bs_td.index[-1].strftime('%Y-%m-%d %H:%M:%S')}\n"
-            f"LeadLocation: {parser.lead_location}, LeadModel: {parser.lead_model}")
+    plt.title(
+        f"BrainSense Time Domain Data - {parser.session_date.strftime(PLOT_DATETIME_FORMAT)} - {parser.lead_location} - {parser.lead_model}\n"
+        f"{df_bs_td.index[0].strftime(PLOT_DATETIME_FORMAT)} - {df_bs_td.index[-1].strftime(PLOT_DATETIME_FORMAT)}\n"
+        f"LeadLocation: {parser.lead_location}, LeadModel: {parser.lead_model}"
+    )
     plt.legend()
     plt.tight_layout()
     plt.savefig(f"{out_path}/brainsense_time_domain_plot_total.pdf")
@@ -88,12 +103,14 @@ def brainsense_timedomain_plot(df_bs_td: pd.DataFrame, parser, out_path: str, in
     plt.figure(figsize=(15, 5))
     samples_plot = 250 * 10
     for ch_idx, ch in enumerate(ch_names):
-        plt.plot(df_bs_td.index, df_bs_td[ch] + 100*ch_idx, label=ch)
+        plt.plot(df_bs_td.index, df_bs_td[ch] + 100 * ch_idx, label=ch)
     plt.xlabel("Time")
     plt.ylabel("Amplitude")
-    plt.title(f"BrainSense Time Domain Data - {parser.session_date.strftime('%Y-%m-%d %H:%M:%S')} - {parser.lead_location} - {parser.lead_model}\n"
-            f"{df_bs_td.index[0].strftime('%Y-%m-%d %H:%M:%S')} - {df_bs_td.index[-1].strftime('%Y-%m-%d %H:%M:%S')}\n"
-            f"LeadLocation: {parser.lead_location}, LeadModel: {parser.lead_model}")
+    plt.title(
+        f"BrainSense Time Domain Data - {parser.session_date.strftime(PLOT_DATETIME_FORMAT)} - {parser.lead_location} - {parser.lead_model}\n"
+        f"{df_bs_td.index[0].strftime(PLOT_DATETIME_FORMAT)} - {df_bs_td.index[-1].strftime(PLOT_DATETIME_FORMAT)}\n"
+        f"LeadLocation: {parser.lead_location}, LeadModel: {parser.lead_model}"
+    )
     plt.legend()
     plt.xlim(df_bs_td.index[0], df_bs_td.index[samples_plot])
     y_min = df_bs_td.iloc[:samples_plot].min().min() - 50
@@ -106,12 +123,14 @@ def brainsense_timedomain_plot(df_bs_td: pd.DataFrame, parser, out_path: str, in
     plt.figure(figsize=(15, 5))
     samples_plot = 250 * 2
     for ch_idx, ch in enumerate(ch_names):
-        plt.plot(df_bs_td.index, df_bs_td[ch] + 100*ch_idx, label=ch)
+        plt.plot(df_bs_td.index, df_bs_td[ch] + 100 * ch_idx, label=ch)
     plt.xlabel("Time")
     plt.ylabel("Amplitude")
-    plt.title(f"BrainSense Time Domain Data - {parser.session_date.strftime('%Y-%m-%d %H:%M:%S')} - {parser.lead_location} - {parser.lead_model}\n"
-            f"{df_bs_td.index[0].strftime('%Y-%m-%d %H:%M:%S')} - {df_bs_td.index[-1].strftime('%Y-%m-%d %H:%M:%S')}\n"
-            f"LeadLocation: {parser.lead_location}, LeadModel: {parser.lead_model}")
+    plt.title(
+        f"BrainSense Time Domain Data - {parser.session_date.strftime(PLOT_DATETIME_FORMAT)} - {parser.lead_location} - {parser.lead_model}\n"
+        f"{df_bs_td.index[0].strftime(PLOT_DATETIME_FORMAT)} - {df_bs_td.index[-1].strftime(PLOT_DATETIME_FORMAT)}\n"
+        f"LeadLocation: {parser.lead_location}, LeadModel: {parser.lead_model}"
+    )
     plt.legend()
     # limit to first 1000 samples
     plt.xlim(df_bs_td.index[0], df_bs_td.index[samples_plot])
@@ -124,7 +143,7 @@ def brainsense_timedomain_plot(df_bs_td: pd.DataFrame, parser, out_path: str, in
     plt.close()
 
     df_bs_td_ = df_bs_td.reset_index()
-    groups = df_bs_td_.groupby(pd.Grouper(key='Time', freq='1min'))
+    groups = df_bs_td_.groupby(pd.Grouper(key="Time", freq="1min"))
 
     if indefinite_streaming is True:
         plt.figure(figsize=(15, 12))
@@ -134,10 +153,12 @@ def brainsense_timedomain_plot(df_bs_td: pd.DataFrame, parser, out_path: str, in
     t_bins_chs_ = []
     for ch_idx, ch in enumerate(ch_names):
         if indefinite_streaming:
-            plt.subplot(len(ch_names) // 2, 2 , ch_idx + 1)
+            plt.subplot(len(ch_names) // 2, 2, ch_idx + 1)
         else:
             plt.subplot(1, len(ch_names), ch_idx + 1)
-        plt.title(f"{ch} - {parser.session_date.strftime('%Y-%m-%d %H:%M:%S')} - {parser.lead_location} - {parser.lead_model}")
+        plt.title(
+            f"{ch} - {parser.session_date.strftime(PLOT_DATETIME_FORMAT)} - {parser.lead_location} - {parser.lead_model}"
+        )
         plt.xlabel("Frequency (Hz)")
         plt.ylabel("PSD (V²/Hz)")
         Pxx_l = []
@@ -145,7 +166,7 @@ def brainsense_timedomain_plot(df_bs_td: pd.DataFrame, parser, out_path: str, in
         for time_bin, df_bin in groups:
             data_ch = df_bin[ch].values
             notnan = ~np.isnan(data_ch)
-            
+
             if not notnan.any():
                 print(f"{time_bin} {ch}: No valid data")
                 # add NaN to Pxx_l and t_bin_l
@@ -157,7 +178,9 @@ def brainsense_timedomain_plot(df_bs_td: pd.DataFrame, parser, out_path: str, in
             group_id = np.cumsum(~notnan)
             group_id[~notnan] = -1
 
-            valid_groups, counts = np.unique(group_id[group_id != -1], return_counts=True)
+            valid_groups, counts = np.unique(
+                group_id[group_id != -1], return_counts=True
+            )
             longest_group = valid_groups[np.argmax(counts)]
             data_clean = data_ch[group_id == longest_group]
 
@@ -184,40 +207,51 @@ def brainsense_timedomain_plot(df_bs_td: pd.DataFrame, parser, out_path: str, in
         t_bins_chs_.append(t_bin_l)
         plt.xlabel("Frequency (Hz)")
         plt.ylabel("PSD (V²/Hz)")
-    plt.suptitle(f"BrainSense Time Domain PSD - {parser.session_date.strftime('%Y-%m-%d %H:%M:%S')} - {parser.lead_location} - {parser.lead_model}\n"
-                f"{df_bs_td.index[0].strftime('%Y-%m-%d %H:%M:%S')} - {df_bs_td.index[-1].strftime('%Y-%m-%d %H:%M:%S')}\n"
-                f"LeadLocation: {parser.lead_location}, LeadModel: {parser.lead_model}")
+    plt.suptitle(
+        f"BrainSense Time Domain PSD - {parser.session_date.strftime(PLOT_DATETIME_FORMAT)} - {parser.lead_location} - {parser.lead_model}\n"
+        f"{df_bs_td.index[0].strftime(PLOT_DATETIME_FORMAT)} - {df_bs_td.index[-1].strftime(PLOT_DATETIME_FORMAT)}\n"
+        f"LeadLocation: {parser.lead_location}, LeadModel: {parser.lead_model}"
+    )
     plt.tight_layout()
     plt.savefig(f"{out_path}/brainsense_time_domain_psd.pdf")
     plt.close()
 
-def time_frequency_plot_td(df_bs_td: pd.DataFrame, indefinite_streaming: bool, parser, out_path: str):
-    
+
+def time_frequency_plot_td(
+    df_bs_td: pd.DataFrame, indefinite_streaming: bool, parser, out_path: str
+):
     if "idx_counter" in df_bs_td.columns:
         df_bs_td = df_bs_td.drop(columns=["idx_counter"])
 
     ch_names = list(df_bs_td.columns)
-    
+
     if indefinite_streaming is False:
         str_prefix = "bstd_"
     else:
         str_prefix = "istd_"
 
     if indefinite_streaming is True:
-        plt.figure(figsize=(15, 15),)
+        plt.figure(
+            figsize=(15, 15),
+        )
     else:
-        plt.figure(figsize=(15, 7),)
+        plt.figure(
+            figsize=(15, 7),
+        )
 
     for ch_idx, ch in enumerate(ch_names):
         if indefinite_streaming:
-            plt.subplot(len(ch_names) // 2, 2 , ch_idx + 1)
+            plt.subplot(len(ch_names) // 2, 2, ch_idx + 1)
         else:
             plt.subplot(1, len(ch_names), ch_idx + 1)
-        
+
         df_ = df_bs_td[ch]
         # chunk data up in 10 s intervals
-        t_bins_10s = pd.date_range(start=df_.index[0], end=df_.index[-1], freq='10S')
-        df_chunks = [df_.loc[t_bins_10s[i]:t_bins_10s[i + 1]] for i in range(len(t_bins_10s) - 1)]
+        t_bins_10s = pd.date_range(start=df_.index[0], end=df_.index[-1], freq="10s")
+        df_chunks = [
+            df_.loc[t_bins_10s[i] : t_bins_10s[i + 1]]
+            for i in range(len(t_bins_10s) - 1)
+        ]
 
         Pxx_chs_ = []
         t_bins_chs_ = []
@@ -227,7 +261,9 @@ def time_frequency_plot_td(df_bs_td: pd.DataFrame, indefinite_streaming: bool, p
                 continue
 
             # Compute PSD
-            f, Pxx_den = signal.welch(df_chunk.fillna(0), fs=250, nperseg=256)
+            f, Pxx_den = signal.welch(
+                df_chunk.fillna(0).to_numpy(), fs=250, nperseg=256
+            )
 
             # Store the PSD and time bin
             Pxx_chs_.append(Pxx_den)
@@ -238,67 +274,79 @@ def time_frequency_plot_td(df_bs_td: pd.DataFrame, indefinite_streaming: bool, p
         Pxx_arr = np.array(Pxx_chs_)
         Pxx_log = np.log(Pxx_arr + 1e-12)  # To avoid log(0)
 
-
         t_num = mdates.date2num(t_bins_chs_)
         extent = [t_num[0], t_num[-1], f[0], f[-1]]
 
-        plt.imshow(Pxx_log.T, aspect='auto', origin='lower',
-                    extent=extent,
-                    cmap='viridis', interpolation='none')
+        plt.imshow(
+            Pxx_log.T,
+            aspect="auto",
+            origin="lower",
+            extent=extent,
+            cmap="viridis",
+            interpolation="none",
+        )
 
-        plt.colorbar(label='log(PSD)')
-        plt.xlabel('Time')
-        plt.ylabel('Frequency (Hz)')
-        plt.title(f'{ch}')
+        plt.colorbar(label="log(PSD)")
+        plt.xlabel("Time")
+        plt.ylabel("Frequency (Hz)")
+        plt.title(f"{ch}")
         plt.clim(-7.5, 4)
         # Format x-axis as dates
         ax = plt.gca()
         ax.xaxis_date()
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M'))
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M"))
         plt.gcf().autofmt_xdate()
 
-    plt.suptitle(f"BrainSense Time Domain TF - {parser.session_date.strftime('%Y-%m-%d %H:%M:%S')} - {parser.lead_location} - {parser.lead_model}\n"
-                f"{df_bs_td.index[0].strftime('%Y-%m-%d %H:%M:%S')} - {df_bs_td.index[-1].strftime('%Y-%m-%d %H:%M:%S')}\n"
-                f"LeadLocation: {parser.lead_location}, LeadModel: {parser.lead_model}")
+    plt.suptitle(
+        f"BrainSense Time Domain TF - {parser.session_date.strftime(PLOT_DATETIME_FORMAT)} - {parser.lead_location} - {parser.lead_model}\n"
+        f"{df_bs_td.index[0].strftime(PLOT_DATETIME_FORMAT)} - {df_bs_td.index[-1].strftime(PLOT_DATETIME_FORMAT)}\n"
+        f"LeadLocation: {parser.lead_location}, LeadModel: {parser.lead_model}"
+    )
     plt.tight_layout()
     start_idx = df_bs_td.index[0]
     end_idx = df_bs_td.index[-1]
-    str_postfix = f"{start_idx.strftime('%Y%m%d_%H%M%S')}_{end_idx.strftime('%Y%m%d_%H%M%S')}"
+    str_postfix = f"{start_idx.strftime(FILE_DATETIME_FORMAT)}_{end_idx.strftime(FILE_DATETIME_FORMAT)}"
     plt.savefig(f"{out_path}/time_domain_tf_{str_prefix}{str_postfix}.pdf")
     plt.close()
 
-def plot_time_domain_ranges(dfs_: list[pd.DataFrame], out_path: str):
 
+def plot_time_domain_ranges(dfs_: list[pd.DataFrame], out_path: str):
     plt.figure(figsize=(13, 8))
 
     for df in dfs_:
         start = df.index[0]
         end = df.index[-1]
-        label = f"{start.strftime('%Y-%m-%d %H:%M:%S')} → {end.strftime('%Y-%m-%d %H:%M:%S')}"
+        label = f"{start.strftime(PLOT_DATETIME_FORMAT)} → {end.strftime(PLOT_DATETIME_FORMAT)}"
         color = [random.random() for _ in range(3)]
-        
+
         plt.axvspan(start, end, alpha=0.3, color=color, label=label)
 
-    plt.gca().xaxis.set_major_formatter(mdates.DateFormatter('%d %H:%M'))
+    plt.gca().xaxis.set_major_formatter(mdates.DateFormatter("%d %H:%M"))
 
     plt.xlabel("Time (Day Hour:Minute)")
     plt.ylabel("Interval Indicator")
     plt.title("Start-End Index Intervals for Each DataFrame")
 
-    plt.legend(loc='center left', bbox_to_anchor=(1, 0.5), title="Intervals", fontsize="small")
+    plt.legend(
+        loc="center left", bbox_to_anchor=(1, 0.5), title="Intervals", fontsize="small"
+    )
 
     plt.tight_layout()
-    #plt.show()
+    # plt.show()
     plt.savefig(f"{out_path}/time_domain_ranges.pdf")
     plt.close()
 
-def plot_df_timeseries(df_plt: pd.DataFrame, out_path: str, brain_sense_timedomain: bool = True):
-    #df_plt = dfs_[15]
+
+def plot_df_timeseries(
+    df_plt: pd.DataFrame, out_path: str, brain_sense_timedomain: bool = True
+):
+    # df_plt = dfs_[15]
     if brain_sense_timedomain:
         str_prefix = "bstd_"
     else:
         str_prefix = "istd_"
-    pdf_path = f"{out_path}/{str_prefix}{df_plt.index[0]}_{df_plt.index[-1]}.pdf"
+    pdf_path = f"{out_path}/{str_prefix}{df_plt.index[0].strftime(FILE_DATETIME_FORMAT)}_{df_plt.index[-1].strftime(FILE_DATETIME_FORMAT)}.pdf"
+    print("pdf_path", pdf_path)
     pdf_ = PdfPages(pdf_path)
     TIME_INTERVAL = 10
     samples = 250 * TIME_INTERVAL
@@ -310,9 +358,11 @@ def plot_df_timeseries(df_plt: pd.DataFrame, out_path: str, brain_sense_timedoma
         df_range_ = df_plt[df_plt["idx_counter"] == idx_cnt]
 
         plt.figure(figsize=(12, 5))
-        plt.suptitle(f"Time Series - idx: {idx_cnt}\n" +
-                        f"ch1: {chs[0]} ch2: {chs[1]}\n" +
-                        f"{df_range_.index[0]} - {df_range_.index[-1]}")
+        plt.suptitle(
+            f"Time Series - idx: {idx_cnt}\n"
+            + f"ch1: {chs[0]} ch2: {chs[1]}\n"
+            + f"{df_range_.index[0]} - {df_range_.index[-1]}"
+        )
         for ch_idx, ch_name in enumerate(chs):
             data_ = df_range_[ch_name].to_numpy()
             # fill nans with 0
@@ -323,46 +373,53 @@ def plot_df_timeseries(df_plt: pd.DataFrame, out_path: str, brain_sense_timedoma
                     sfreq=fs,
                     l_freq=105,
                     h_freq=95,
-                    method='iir',
-                    verbose=False
+                    method="iir",
+                    verbose=False,
                 )
                 data_filtered = mne.filter.filter_data(
                     data_filtered,
                     sfreq=fs,
                     l_freq=65,
                     h_freq=55,
-                    method='iir',
-                    verbose=False
+                    method="iir",
+                    verbose=False,
                 )
                 data_filtered = mne.filter.filter_data(
                     data_filtered,
                     sfreq=fs,
                     l_freq=0.5,
                     h_freq=None,
-                    method='iir',
-                    verbose=False
+                    method="iir",
+                    verbose=False,
                 )
                 data_ = data_filtered
 
-            plt.subplot(2, 3, ch_idx*3 + 1)
-            plt.plot(np.arange(0, data_.shape[0]/fs, 1/fs), data_, linewidth=0.5)
-            plt.gca().spines['right'].set_visible(False); plt.gca().spines['top'].set_visible(False)
+            plt.subplot(2, 3, ch_idx * 3 + 1)
+            plt.plot(np.arange(0, data_.shape[0] / fs, 1 / fs), data_, linewidth=0.5)
+            plt.gca().spines["right"].set_visible(False)
+            plt.gca().spines["top"].set_visible(False)
             plt.xlabel("Time [s]")
             plt.ylabel("Amplitude [a.u.]")
-            plt.subplot(2, 3, ch_idx*3 + 2)
-            plt.plot(np.arange(0, data_[:250].shape[0]/fs, 1/fs), data_[:250], linewidth=0.5)
-            plt.gca().spines['right'].set_visible(False); plt.gca().spines['top'].set_visible(False)
+            plt.subplot(2, 3, ch_idx * 3 + 2)
+            plt.plot(
+                np.arange(0, data_[:250].shape[0] / fs, 1 / fs),
+                data_[:250],
+                linewidth=0.5,
+            )
+            plt.gca().spines["right"].set_visible(False)
+            plt.gca().spines["top"].set_visible(False)
             plt.xlabel("Time [s]")
             plt.ylabel("Amplitude [a.u.]")
-            plt.subplot(2, 3, ch_idx*3 + 3)
+            plt.subplot(2, 3, ch_idx * 3 + 3)
             if FILTER is False:
                 data_ = np.nan_to_num(data_, nan=0.0)
             f, Pxx = signal.welch(data_, fs=fs, nperseg=250)
             plt.plot(f, np.log(Pxx), linewidth=0.5)
-            plt.gca().spines['right'].set_visible(False); plt.gca().spines['top'].set_visible(False)
+            plt.gca().spines["right"].set_visible(False)
+            plt.gca().spines["top"].set_visible(False)
             plt.xlabel("Frequency [Hz]")
             plt.ylabel("PSD [a.u.]")
         plt.tight_layout()
-        pdf_.savefig(bbox_inches='tight')
+        pdf_.savefig(bbox_inches="tight")
         plt.close()
     pdf_.close()

--- a/percept_parser/stim_settings.py
+++ b/percept_parser/stim_settings.py
@@ -416,8 +416,6 @@ class PatientStimSettingHistory:
         for session1_settings, session2_settings in self._get_session_pairs():
             for setting in session1_settings:
                 if setting not in session2_settings:
-                    # print(setting)
-                    # print(session2_settings)
                     warnings.warn(
                         f"Final group {setting.group_name} settings"
                         f"from {Interval(setting.start_time, setting.end_time)} "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,5 @@ dependencies = [
     "scipy>=1.15.3",
     "tqdm>=4.67.1",
 ]
+[tool.setuptools]
+py-modules = []


### PR DESCRIPTION
The last changes to the time imputation algorithm caused unexpected results with the IndefiniteStreaming type of data, since for some reason the packets where split into 2 consecutive packets of 38 and 25 or 24 datapoints with the same timestamps, instead of a single 62 or 63 packet per sampling interval.

Like this
```
GlobalPacketSizes: "38,38,38,38,35,38,25,38,24,38,25,38,24,38,25,38,24
TicksInMses: "1428250,1428250,1428250,1428500,1428500,1428750,1428750,
```

This did not pair well with the algorithm I wrote, and was leaving gaps of data every time 2 consecutive packets with identical tick timestamp appeared.
The problem was not apparent for BrainSenseTimeDomain data, and I did not detect it as that was the example data I had available.

To fix this, I have implemented, verbatim, the time assignation algorithm from the Medtronic whitepaper, starting from the last datapoint backwards. This has fixed the issue as far as I have been able to see from the test data i have.

PS. I have also introduced a fix for the plot file names in Windows, removing Windows filesystem illegal characters.