### PR TITLE
fix #7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "my-parser-scripts"
 version = "0.1.0"
@@ -15,4 +19,7 @@ dependencies = [
     "tqdm>=4.67.1",
 ]
 [tool.setuptools]
-py-modules = []
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["percept_parser*"]


### PR DESCRIPTION
In `pyproject.toml`, we had:

[tool.setuptools]
py-modules = []
That tells setuptools to package nothing as top-level modules, and we also hadn’t configured package discovery for percept_parser, so editable install produced a distribution that didn’t include percept_parser. Result: ModuleNotFoundError: No module named 'percept_parser'.